### PR TITLE
bump pytest_mozwebqa to v1.1 to gain support for --skipurlcheck

### DIFF
--- a/tests/python-selenium/requirements.txt
+++ b/tests/python-selenium/requirements.txt
@@ -4,7 +4,7 @@
 BeautifulSoup==3.2.0    # Only required for doing link checking without Selenium
 py==1.4.9
 pytest==2.2.4
-pytest-mozwebqa==1.0
+pytest-mozwebqa==1.1
 PyYAML==3.10
 requests==1.2.0
 selenium


### PR DESCRIPTION
Bumping the version number of pytest-mozwebqa to 1.1 so we can gain the <code>--skipurlcheck</code> flag.

This change only effects our Selenium tests; the default behavior of pytest-mozwebqa is to do a schema check of <code>--baseurl</code>. Ultimately because we're testing against <code>about:healthreport</code> we need this functionality.

https://github.com/davehunt/pytest-mozwebqa/blob/master/CHANGELOG.md#11
