### PR TITLE
add travis-ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "0.10"
+  - "0.8"


### PR DESCRIPTION
set up travis-ci integration testing for fhr-jelly.

tested and working with my local fork (https://travis-ci.org/lonnen/fhr-jelly)
