### PR TITLE
String fixes for mobile template

### DIFF
--- a/templates/mobile.html
+++ b/templates/mobile.html
@@ -31,8 +31,8 @@
                 <h3><a href="#customization" target="_self" class="navigate">{{ _('Customization') }}</a></h3>
                 <p>{{ _('Extensions, plugins, and number of installed add-ons.') }}</p>
                 <h3><a href="#performance" target="_self" class="navigate">{{ _('Performance') }}</a></h3>
-                <p>{{ _('Key performance measures, such as launch speed') }}</p>
-                <h3><a href="#weartear" target="_self" class="navigate">{{ _('Wear and tear') }}</a></h3>
+                <p>{{ _('Key performance measures, such as launch speed.') }}</p>
+                <h3><a href="#weartear" target="_self" class="navigate">{{ _('Wear and Tear') }}</a></h3>
                 <p>{{ _('Browsing duration, install time, number of bookmarks and pages.') }}</p>
             </div>
         </section>
@@ -121,7 +121,7 @@
             </ul>
             <div class="main" role="main">
                 <h2>{{ _('Performance') }}</h2>
-                <p>{{ _('Key performance measures, such as launch speed') }}</p>
+                <p>{{ _('Key performance measures, such as launch speed.') }}</p>
                 <dl>
                     <dt id="search_count">{{ _('Search Counts:') }}</dt>
                     <dd>{{ _('A count of how many searches you issued to each of Mozilla\'s partner providers.') }}</dd>
@@ -138,7 +138,7 @@
             </ul>
             <div class="main" role="main">
                 <h2>{{ _('Wear and Tear') }}</h2>
-                <p>{{ _('Key performance measures, such as launch speed') }}</p>
+                <p>{{ _('Key performance measures, such as launch speed.') }}</p>
                 <dl>
                     <dt id="profile_creation">{{ _('Profile Creation:') }}</dt>
                     <dd>{{ _('The day on which your browser profile was created. Counted in days since January 1st 1970.') }}</dd>


### PR DESCRIPTION
Wear and tear -> Wear and Tear to avoid having a second string extracted.

Performance paragraph: it's the only one without a closing period.
