### PR TITLE
Customization -> Customizations (reuse existing string)

### DIFF
--- a/templates/mobile.html
+++ b/templates/mobile.html
@@ -28,7 +28,7 @@
                 <p>{{ _('Firefox Health Report records information about your browser and device. You can <a href="#raw" class="navigate">see the information we record.</a> You can also see what you share with Mozilla.') }}</p>
                 <h3><a href="#configuration" target="_self" class="navigate">{{ _('Configuration') }}</a></h3>
                 <p>{{ _('Device hardware, operating system, Firefox version.') }}</p>
-                <h3><a href="#customization" target="_self" class="navigate">{{ _('Customization') }}</a></h3>
+                <h3><a href="#customization" target="_self" class="navigate">{{ _('Customizations') }}</a></h3>
                 <p>{{ _('Extensions, plugins, and number of installed add-ons.') }}</p>
                 <h3><a href="#performance" target="_self" class="navigate">{{ _('Performance') }}</a></h3>
                 <p>{{ _('Key performance measures, such as launch speed.') }}</p>
@@ -94,10 +94,10 @@
         <section id="customization" class="panel inactive">
             <ul class="breadcrumbs">
                 <li><a href="#dashboard" target="_self" class="navigate">{{ _('Home') }}</a> &raquo;</li>
-                <li>{{ _('Customization') }}</li>
+                <li>{{ _('Customizations') }}</li>
             </ul>
             <div class="main" role="main">
-                <h2>{{ _('Customization') }}</h2>
+                <h2>{{ _('Customizations') }}</h2>
                 <p>{{ _('Whether Firefox fetches add-on blocklist results to protect you against malicious add-ons. Defaults to on.') }}</p>
                 <dl>
                     <dt id="telemetry">{{ _('Telemetry Enabled:') }}<span></span></dt>


### PR DESCRIPTION
Reuse the existing string from standard template, leave the ID alone.
