### PR TITLE
Bug 911061 - Ignore case when filtering l10n metatags

### DIFF
--- a/vendor/dotlang/translate.py
+++ b/vendor/dotlang/translate.py
@@ -13,7 +13,7 @@ import settings
 
 
 # Metadata markers to be filtered out of translations.
-METADATA_MARKERS = re.compile(r'\s?{(ok|l10n-extra)}\s?')
+METADATA_MARKERS = re.compile(r'\s?{(ok|l10n-extra)}\s?', re.IGNORECASE)
 
 # Don't even THINK this is thread-safe.
 CACHE = {}


### PR DESCRIPTION
@lauraxt r?

Talked with :espressive on IRC. This file is in vendor but it's not pulled from external sources, so it should be safe to fix it directly here.
