### PR TITLE
Bug 918415: ignore l10n comments at parsing time

### DIFF
--- a/vendor/dotlang/translate.py
+++ b/vendor/dotlang/translate.py
@@ -31,11 +31,16 @@ def parse(path):
 
         for line in lines:
             line = line.strip()
-            if line != '':
-                if line[0] == ';':
-                    source = line
-                elif source:
-                    trans[source[1:]] = line
+            if not line:
+                continue
+
+            if line[0] == '#':
+                continue
+
+            if line[0] == ';':
+                source = line[1:]
+            elif source:
+                trans[source] = line
 
     return trans
 


### PR DESCRIPTION
This patch also makes parse() code closer to what we use today on mozilla.org 
