### PR TITLE
Remove outdated Node.js 0.8 build target on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "0.10"
-  - "0.8"
 notifications:
   email: false
   irc: "irc.mozilla.org#fhr"


### PR DESCRIPTION
This fixes the failing build.
