### PR TITLE
Copy files to v4 directory for unified telemetry

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -94,6 +94,7 @@ def main():
     # Place static files into output dir.
     STATIC_PATH = os.path.join(OUTPUT_PATH, 'static')
     MOBILE_STATIC_PATH = os.path.join(STATIC_PATH, 'mobile')
+    V4_STATIC_PATH = os.path.join(STATIC_PATH, 'v4')
     for folder in settings.STATIC_FOLDERS:
         folder_path = os.path.join(STATIC_PATH, folder)
         shutil.copytree(os.path.join(settings.ROOT, folder),
@@ -104,15 +105,22 @@ def main():
         shutil.copytree(os.path.join(settings.MOBILE_ROOT, folder),
                         mobile_folder_path)
 
+    for folder in settings.V4_STATIC_FOLDERS:
+        v4_folder_path = os.path.join(V4_STATIC_PATH, folder)
+        shutil.copytree(os.path.join(settings.ROOT, folder),
+                        v4_folder_path)
+
     for lang in settings.LANGS:
         # Make language dir, or symlink to fallback language
         LANG_PATH = os.path.join(OUTPUT_PATH, lang)
         MOBILE_LANG_PATH = os.path.join(LANG_PATH, 'mobile')
+        V4_LANG_PATH = os.path.join(LANG_PATH, 'v4')
         if lang in settings.LANG_FALLBACK:
             os.symlink(settings.LANG_FALLBACK[lang], LANG_PATH)
             continue
         else:
             os.makedirs(LANG_PATH)
+            os.makedirs(V4_LANG_PATH)
             if lang in settings.LANG_MOBILE_FALLBACK:
                 MOBILE_FALLBACK_PATH = os.path.join(
                                         '..',
@@ -133,6 +141,11 @@ def main():
                 os.symlink(os.path.join(settings.MOBILE_STATIC_SYMLINK_PATH, folder),
                            os.path.join(LANG_PATH, 'mobile', folder))
 
+        # symlink v4 static folders into language dir
+        for folder in settings.V4_STATIC_FOLDERS:
+            os.symlink(os.path.join(settings.V4_STATIC_SYMLINK_PATH, folder),
+                       os.path.join(LANG_PATH, 'v4', folder))
+
         # Data to be passed to template
         data = {
             'LANG': lang,
@@ -146,11 +159,13 @@ def main():
         for platform, template in templates.iteritems():
             OUTPUT_LANG_PATH = (LANG_PATH if platform == 'html' else
                                 os.path.join(LANG_PATH, 'mobile'))
+            V4_OUTPUT_LANG_PATH = os.path.join(LANG_PATH, 'v4')
             tmpl = ENV.get_template(template)
 
             if platform =='mobile' and lang in settings.LANG_MOBILE_FALLBACK:
                 continue
-            write_output(OUTPUT_LANG_PATH, 'index.html', tmpl.render(data));
+            write_output(OUTPUT_LANG_PATH, 'index.html', tmpl.render(data))
+            write_output(V4_OUTPUT_LANG_PATH, 'index.html', tmpl.render(data))
 
 
 if __name__ == '__main__':

--- a/settings.py
+++ b/settings.py
@@ -3,6 +3,7 @@ import os
 
 ROOT = os.path.dirname(__file__)
 MOBILE_ROOT = os.path.join(ROOT, 'mobile')
+V4_ROOT = os.path.join(ROOT, 'v4')
 
 # Root folder for build artifacts
 BUILD_ROOT = os.path.join(ROOT, 'build/')
@@ -11,9 +12,11 @@ BUILD_ROOT = os.path.join(ROOT, 'build/')
 # symlinked from the locale directories.
 STATIC_FOLDERS = ['css', 'fonts', 'img', 'js', 'json']
 MOBILE_STATIC_FOLDERS = ['css', 'fonts', 'img', 'js']
+V4_STATIC_FOLDERS = ['css', 'fonts', 'img', 'js']
 
 STATIC_SYMLINK_PATH = '../static'
 MOBILE_STATIC_SYMLINK_PATH = '../../static/mobile'
+V4_STATIC_SYMLINK_PATH = '../../static/v4'
 
 # L10n dir
 LOCALE_DIR = os.path.join(ROOT, 'locale')


### PR DESCRIPTION
The new unified telemetry will take the place of the old FHR mechanism for the "health report", including a change to the API. The data collected and reported for the health report (base data, opt-out data for the release population) remains essentially the same; the UX presented to the user remains essentially the same.

We'll have both older and newer clients out in the wild for some time, so we need to host two versions of this content, which make use of the two APIs. Our proposal is to create a 'v4' version of the site that mirrors the files at the root directory, with minor changes. URLs then become:
fhr v2:  https://fhr.cdn.mozilla.net/%LOCALE%/
mobile:  https://fhr.cdn.mozilla.net/%LOCALE%/mobile/
unified telemetry/fhr v4:  https://fhr.cdn.mozilla.net/%LOCALE%/v4/

This PR currently copies the various files into the static v4 directory, and then sets up symlinks in the various locale directories (following the same pattern as the v2/html files).

It does not yet copy a new index or js files. (@bsmedberg will make the API changes.) Pushing this as is would allow us to go ahead and patch the client with the new v4 url. https://bugzilla.mozilla.org/show_bug.cgi?id=1180673 

I've tested the v4 url by changing my browser settings, and loading various locales directly in the browser.

@lauraxt, @lonnen r? (let me know if I've missed anything or need to make changes for local tests)
/cc @georgf