### PR TITLE
Fix v4 plugin counting

### DIFF
--- a/tests/json/plugins_v4.json
+++ b/tests/json/plugins_v4.json
@@ -1,0 +1,141 @@
+{
+  "ping": {
+    "environment": {
+      "addons": {
+        "activeAddons": {
+          "{8620c15f-30dc-4dba-a131-7c5d20cf4a29}": {
+            "blocklisted": false,
+            "description": "Useful tools for the nightly tester.",
+            "name": "Nightly Tester Tools",
+            "userDisabled": false,
+            "appDisabled": false,
+            "version": "3.7.1-signed",
+            "scope": 1,
+            "type": "extension",
+            "foreignInstall": false,
+            "hasBinaryComponents": false,
+            "installDay": 16693,
+            "updateDay": 16693,
+            "signedState": 2
+          }
+        },
+        "activePlugins": [
+          {
+            "name": "Shockwave Flash",
+            "version": "19.0.0.185",
+            "description": "Shockwave Flash 19.0 r0",
+            "blocklisted": false,
+            "disabled": false,
+            "clicktoplay": false,
+            "mimeTypes": [
+              "application/x-shockwave-flash",
+              "application/futuresplash"
+            ],
+            "updateDay": 16700
+          },
+          {
+            "name": "QuickTime Plug-in 7.7.8",
+            "version": "7.7.8.0",
+            "description": "The QuickTime Plugin allows you to view a wide variety of multimedia content in Web pages. For more ",
+            "blocklisted": false,
+            "disabled": false,
+            "clicktoplay": true,
+            "mimeTypes": [
+              "application\/sdp",
+              "application\/x-sdp",
+              "application\/x-rtsp",
+              "video\/quicktime",
+              "video\/flc",
+              "audio\/x-wav",
+              "audio\/wav"
+            ],
+            "updateDay": 16707
+          },
+          {
+            "name": "QuickTime Plug-in 7.7.8",
+            "version": "7.7.8.0",
+            "description": "The QuickTime Plugin allows you to view a wide variety of multimedia content in Web pages. For more ",
+            "blocklisted": false,
+            "disabled": false,
+            "clicktoplay": true,
+            "mimeTypes": [
+              "audio\/aiff",
+              "audio\/x-aiff",
+              "audio\/basic",
+              "audio\/mid",
+              "audio\/vnd.qcelp",
+              "audio\/x-gsm",
+              "audio\/amr",
+              "audio\/aac"
+            ],
+            "updateDay": 16707
+          },
+          {
+            "name": "QuickTime Plug-in 7.7.8",
+            "version": "7.7.8.0",
+            "description": "The QuickTime Plugin allows you to view a wide variety of multimedia content in Web pages. For more ",
+            "blocklisted": false,
+            "disabled": false,
+            "clicktoplay": true,
+            "mimeTypes": [
+              "audio\/x-aac",
+              "audio\/x-caf",
+              "audio\/x-ac3",
+              "video\/x-mpeg",
+              "video\/mpeg"
+            ],
+            "updateDay": 16707
+          },
+          {
+            "name": "QuickTime Plug-in 7.7.8",
+            "version": "7.7.8.0",
+            "description": "The QuickTime Plugin allows you to view a wide variety of multimedia content in Web pages. For more ",
+            "blocklisted": false,
+            "disabled": false,
+            "clicktoplay": true,
+            "mimeTypes": [
+              "audio\/mpeg",
+              "audio\/x-mpeg",
+              "video\/3gpp",
+              "audio\/3gpp",
+              "video\/3gpp2",
+              "audio\/3gpp2",
+              "video\/sd-video"
+            ],
+            "updateDay": 16707
+          },
+          {
+            "name": "QuickTime Plug-in 7.7.8",
+            "version": "7.7.8.0",
+            "description": "The QuickTime Plugin allows you to view a wide variety of multimedia content in Web pages. For more ",
+            "blocklisted": false,
+            "disabled": false,
+            "clicktoplay": true,
+            "mimeTypes": [
+              "application\/x-mpeg",
+              "video\/mp4",
+              "audio\/mp4",
+              "audio\/x-m4a",
+              "audio\/x-m4p",
+              "audio\/x-m4b",
+              "video\/x-m4v"
+            ],
+            "updateDay": 16707
+          }
+        ],
+        "activeGMPlugins": {
+          "gmp-gmpopenh264": {
+            "version": "1.4",
+            "userDisabled": false,
+            "applyBackgroundUpdates": 1
+          },
+          "some-drm-stuff": {
+            "version": "3.5",
+            "userDisabled": true,
+            "applyBackgroundUpdates": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/lib/unit_v4.js
+++ b/tests/lib/unit_v4.js
@@ -34,3 +34,15 @@ asyncTest('test-totals', function() {
         start();
     });
 });
+
+asyncTest('test-plugins', function() {
+    $.getJSON('/tests/json/plugins_v4.json', function(data) {
+        var counts = countPlugins(data.ping.environment);
+
+        equal(counts.activeAddons, 1, 'Expected 1 active addon and got ' + counts.activeAddons);
+        equal(counts.activePlugins, 2, 'Expected 2 active plugins (1 NPAPI and 1 GMP) and got ' + counts.activePlugins);
+        equal(counts.clickToPlayPlugins, 1, 'Expected 1 click-to-play plugin and got ' + counts.clickToPlayPlugins);
+
+        start();
+    });
+});


### PR DESCRIPTION
This fixes [bug 1220110](https://bugzilla.mozilla.org/show_bug.cgi?id=1220110) & [bug 1220119](https://bugzilla.mozilla.org/show_bug.cgi?id=1220119).

* Plugins with multiple binaries were collapsed into one entry in the
add-on manager (based on name & description), but counted as multiple
in about:healthreport.
I updated this to use the same collapsing strategy to avoid confusion.
* Before bug 1218842 / bug 1222503, GMP plugins were present in the
environment even if disabled.
They are now filtered out in about:healthreport to get correct counts.