### PR TITLE
Add more locales to FHR to avoid 404

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -28,17 +28,15 @@ LANG_FILENAME = 'fhr.lang'
 
 # List of languages.
 LANGS = (
-    'ach', 'af', 'an', 'ar', 'as', 'ast', 'az', 'bg', 'bn-BD',
-    'bn-IN', 'br', 'bs', 'ca', 'cak', 'cs', 'cy', 'da', 'de',
-    'dsb', 'el', 'en-GB', 'en-US', 'en-ZA', 'eo', 'es-AR',
-    'es-CL', 'es-ES', 'es-MX', 'et', 'eu', 'fa', 'ff', 'fi',
-    'fr', 'fy-NL', 'ga-IE', 'gd', 'gl', 'gu-IN', 'he', 'hi-IN',
-    'hr', 'hsb', 'hu', 'hy-AM', 'id', 'is', 'it', 'ja-JP-mac',
-    'ja', 'ka', 'kab', 'kk', 'km', 'kn', 'ko', 'lij', 'lt',
-    'lv', 'mai', 'mk', 'ml', 'mr', 'ms', 'my', 'nb-NO', 'nl',
-    'nn-NO', 'or', 'pa-IN', 'pl', 'pt-BR', 'pt-PT', 'rm',
-    'ro', 'ru', 'si', 'sk', 'sl', 'son', 'sq', 'sr', 'sv-SE',
-    'ta', 'te', 'th', 'tr', 'uk', 'ur', 'uz', 'vi', 'xh',
+    'ach', 'af', 'an', 'ar', 'as', 'ast', 'az', 'bg', 'bn-BD', 'bn-IN', 'br',
+    'bs', 'ca', 'cak', 'cs', 'cy', 'da', 'de', 'dsb', 'el', 'en-GB', 'en-US',
+    'en-ZA', 'eo', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'et', 'eu', 'fa', 'ff',
+    'fi', 'fr', 'fy-NL', 'ga-IE', 'gd', 'gl', 'gn', 'gu-IN', 'he', 'hi-IN',
+    'hr', 'hsb', 'hu', 'hy-AM', 'id', 'is', 'it', 'ja', 'ja-JP-mac', 'ka',
+    'kab', 'kk', 'km', 'kn', 'ko', 'lij', 'lo', 'lt', 'ltg', 'lv', 'mai', 'mk',
+    'ml', 'mr', 'ms', 'my', 'nb-NO', 'ne-NP', 'nl', 'nn-NO', 'or', 'pa-IN',
+    'pl', 'pt-BR', 'pt-PT', 'rm', 'ro', 'ru', 'si', 'sk', 'sl', 'son', 'sq',
+    'sr', 'sv-SE', 'ta', 'te', 'th', 'tl', 'tr', 'uk', 'ur', 'uz', 'vi', 'xh',
     'zh-CN', 'zh-TW', 'zu',
 )
 


### PR DESCRIPTION
We have several locales shipping in Aurora and one, Guaraní, even in Beta/Release not enabled in FHR: gn, lo, ltg, ne-NP, tl.

They're currently not translated, but we should at least show en-US content for them, not a 404 page (is there data about people hitting those?)

Diff is bigger, but it's generated by editor cutting the list at 80 characters instead of the existing manual formatting.